### PR TITLE
Fix OwnerAndTeamCanMount option and improve spawn rotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Permissions
 
-* `spawnmini.mini`  -- Allows player to spawn a minicopter with `/mini`
-* `spawnmini.nocd` -- Gives player no cooldown for `/mini` chat command
+* `spawnmini.mini`  -- Allows player to spawn a minicopter with `/mymini`
+* `spawnmini.nocd` -- Gives player no cooldown for `/mymini` chat command
 * `spawnmini.nomini` -- Allows player to use `/nomini` chat command 
 * `spawnmini.nodecay` -- Doesn't allow the player's minicopter to decay
 * `spawnmini.unlimitedfuel` -- Gives the player unlimited fuel when they spawn their minicopter

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -1,4 +1,4 @@
-using Oxide.Core;   
+using Oxide.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -23,7 +23,7 @@ namespace Oxide.Plugins
 
         #region Hooks
 
-        private void Loaded() 
+        private void Loaded()
         {
             _config = Config.ReadObject<PluginConfig>();
 
@@ -46,7 +46,7 @@ namespace Oxide.Plugins
                 Unsubscribe(nameof(CanMountEntity));
         }
 
-        void Unload() 
+        void Unload()
             => Interface.Oxide.DataFileSystem.WriteObject("SpawnMini", _data);
 
         void OnEntityKill(MiniCopter mini)
@@ -119,7 +119,7 @@ namespace Oxide.Plugins
                     else
                     {
                         player.ChatMessage(lang.GetMessage("mini_current", this, player.UserIDString));
-                    } 
+                    }
                 }
                 else if (_data.cooldown.ContainsKey(player.UserIDString) && !permission.UserHasPermission(player.UserIDString, _noCooldown))
                 {
@@ -140,7 +140,7 @@ namespace Oxide.Plugins
                     SpawnMinicopter(player);
                 }
             }
-        }        
+        }
 
         [ChatCommand("fmini")]
         private void FetchMinicopter(BasePlayer player, string command, string[] args)
@@ -179,7 +179,7 @@ namespace Oxide.Plugins
                 }
             }
         }
-        
+
         [ChatCommand("nomini")]
         private void NoMinicopter(BasePlayer player, string command, string[] args)
         {
@@ -242,7 +242,7 @@ namespace Oxide.Plugins
             if (!player.IsBuildingBlocked() || _config.canSpawnBuildingBlocked)
             {
                 RaycastHit hit;
-                if (Physics.Raycast(player.eyes.HeadRay(), out hit, Mathf.Infinity, 
+                if (Physics.Raycast(player.eyes.HeadRay(), out hit, Mathf.Infinity,
                     LayerMask.GetMask("Construction", "Default", "Deployed", "Resource", "Terrain", "Water", "World")))
                 {
                     if (hit.distance > _config.maxSpawnDistance)
@@ -276,7 +276,7 @@ namespace Oxide.Plugins
 
                         if (!permission.UserHasPermission(player.UserIDString, _noCooldown))
                         {
-                            
+
 
                             // Sloppy but works
                             // TODO: Improve later
@@ -361,7 +361,7 @@ namespace Oxide.Plugins
             if (mini != null && _data.playerMini.ContainsValue(mini.net.ID))
                 return true;
 
-            return false; 
+            return false;
         }
 
         #endregion


### PR DESCRIPTION
- Fix OwnerAndTeamCanMount option
- Spawn the minicopter pointing behind the player's left shoulder to make it easier to mount
- Fix incorrect command in permissions section
- Removed some unnecessary trailing whitespace in the code