### PR TITLE
Various fixes and new features

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,25 +27,41 @@ bool IsPlayerOwned(MiniCopter);
 
 ## Configuration
 
+Default configuration:
 ```json
 {
-  "AssetPrefab": "assets/content/vehicles/minicopter/minicopter.entity.prefab", -- Prefab you would like to spawn
-  "CanSpawnBuildingBlocked": false,  -- Can player spawn a minicopter while building blocked
-  "CanDespawnWhileOccupied": false,  -- Can player use /nomini while the mini is mounted
-  "CanFetchWhileOccupied": false,  -- Can player use /fmini while the mini is mounted (will dismount players)
-  "FuelAmount": 0,  -- Amount of low grade fuel to add to minicopters when spawned, -1 for max stack size (ignored for players with the unlimited fuel permission)
-  "MaxNoMiniDistance": 300.0, -- The maximum distance the player can be from the minicopter when using /nomini and /fmini (set to -1 for unlimited distance)
-  "MaxSpawnDistance": 5.0, -- How far away can the player spawn a minicopter
-  "UseFixedSpawnDistance": false,  -- Set to true to spawn the minicopter at a fixed distance in front of the player instead of where they are looking (MaxSpawnDistance will be ignored)
-  "OwnerAndTeamCanMount": false, -- If you want only the owner and their team members to be able to mount the mini set this to true
-  "PermissionCooldowns": { -- These are the cooldown tiers feel free to add/change as many as you like just make sure users only have one for now
+  "AssetPrefab": "assets/content/vehicles/minicopter/minicopter.entity.prefab",
+  "CanDespawnWhileOccupied": false,
+  "CanFetchWhileOccupied": false,
+  "CanSpawnBuildingBlocked": false,
+  "FuelAmount": 0,
+  "MaxNoMiniDistance": 300.0,
+  "MaxSpawnDistance": 5.0,
+  "OwnerAndTeamCanMount": false,
+  "PermissionCooldowns": {
     "spawnmini.tier1": 86400.0,
     "spawnmini.tier2": 43200.0,
     "spawnmini.tier3": 21600.0
   },
-  "SpawnHealth": 750.0 -- The health the minicopter spawns with
+  "SpawnHealth": 750.0,
+  "UseFixedSpawnDistance": false
 }
 ```
+
+Options explained:
+* `CanDespawnWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/nomini` while their minicopter is mounted. Regardless of this setting, players cannot despawn their minicopter while they mounted on it.
+* `CanFetchWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/fmini` while the minicopter is mounted. Mounted players will be dismounted automatically. Regardless of this setting, players cannot fetched their minicopter while they are mounted on it.
+* `CanSpawnBuildingBlocked` (`true` or `false`) -- Whether to allow players to spawn a minicopter while building blocked.
+* `FuelAmount` -- Amount of low grade fuel to add to minicopters when spawned. Set to `-1` for max stack size (which depends on the server, but is 500 in vanilla). Does not apply to minicopters spawned for players who have the `spawnmini.unlimitedfuel` permission.
+* `MaxNoMiniDistance` -- The maximum distance players can be from their minicopter to use `/nomini` or `/fmini`. Set to `-1` to allow those commands at unlimited distance.
+* `MaxSpawnDistance` -- The maximum distance away that players are allowed to spawn their minicopter.
+* `OwnerAndTeamCanMount` (`true` or `false`) -- Set to `true` to only allow the owner and their team members to be able to mount the minicopter.
+* `PermissionCooldowns` -- Use these settings to customize cooldowns for different player groups. For example, set `"spawnmini.tier1": 3600.0` and then grant the `spawnmini.tier1` permission to a group of players to assign them a 1 hour cooldown for spawning their minicopters.
+  * If a player has multiple cooldown permissions, the lowest is used.
+  * If a player has no cooldown permissions, their cooldown will be 1 day.
+  * You can add as many cooldown tiers as you would like, but you should prefix them all with `spawnmini` to prevent warnings in the server logs.
+* `SpawnHealth` -- The health minicopters will spawn with.
+* `UseFixedSpawnDistance` (`true` or `false`) -- Set to `true` to cause minicopters to spawn directly in front of players at a fixed distance, disregarding the `MaxSpawnDistance` setting. Performs no terrain checks.
 
 ## Localization
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ bool IsPlayerOwned(MiniCopter);
   "CanSpawnBuildingBlocked": false,  -- Can player spawn a minicopter while building blocked
   "CanDespawnWhileOccupied": false,  -- Can player use /nomini while the mini is mounted
   "CanFetchWhileOccupied": false,  -- Can player use /fmini while the mini is mounted (will dismount players)
+  "FuelAmount": 0,  -- Amount of low grade fuel to add to minicopters when spawned, -1 for max stack size (ignored for players with the unlimited fuel permission)
   "MaxNoMiniDistance": 300.0, -- The maximum distance the player can be from the minicopter when using /nomini and /fmini (set to -1 for unlimited distance)
   "MaxSpawnDistance": 5.0, -- How far away can the player spawn a minicopter
   "OwnerAndTeamCanMount": false, -- If you want only the owner and their team members to be able to mount the mini set this to true

--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ bool IsPlayerOwned(MiniCopter);
   "FuelAmount": 0,  -- Amount of low grade fuel to add to minicopters when spawned, -1 for max stack size (ignored for players with the unlimited fuel permission)
   "MaxNoMiniDistance": 300.0, -- The maximum distance the player can be from the minicopter when using /nomini and /fmini (set to -1 for unlimited distance)
   "MaxSpawnDistance": 5.0, -- How far away can the player spawn a minicopter
+  "UseFixedSpawnDistance": false,  -- Set to true to spawn the minicopter at a fixed distance in front of the player instead of where they are looking (MaxSpawnDistance will be ignored)
   "OwnerAndTeamCanMount": false, -- If you want only the owner and their team members to be able to mount the mini set this to true
   "PermissionCooldowns": { -- These are the cooldown tiers feel free to add/change as many as you like just make sure users only have one for now
     "spawnmini.tier1": 86400.0,

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ bool IsPlayerOwned(MiniCopter);
 {
   "AssetPrefab": "assets/content/vehicles/minicopter/minicopter.entity.prefab", -- Prefab you would like to spawn
   "CanSpawnBuildingBlocked": false,  -- Can player spawn a minicopter while building blocked
+  "CanDespawnWhileOccupied": false,  -- Can player use /nomini while the mini is mounted
+  "CanFetchWhileOccupied": false,  -- Can player use /fmini while the mini is mounted (will dismount players)
   "MaxNoMiniDistance": 300.0, -- The maximum distance the player can be from the minicopter when using /nomini and /fmini (set to -1 for unlimited distance)
   "MaxSpawnDistance": 5.0, -- How far away can the player spawn a minicopter
   "OwnerAndTeamCanMount": false, -- If you want only the owner and their team members to be able to mount the mini set this to true

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -344,15 +344,7 @@ namespace Oxide.Plugins
                 return;
             }
 
-            // Credit Original MyMinicopter Plugin
-            Quaternion rotation = player.GetNetworkRotation();
-            Vector3 forward = rotation * Vector3.forward;
-            Vector3 straight = Vector3.Cross(Vector3.Cross(Vector3.up, forward), Vector3.up).normalized;
-            Vector3 position = player.transform.position + straight * 5f;
-            position.y = player.transform.position.y + 2f;
-
-            if (position == null) return;
-            MiniCopter mini = GameManager.server.CreateEntity(_config.assetPrefab, position, GetIdealRotationForPlayer(player)) as MiniCopter;
+            MiniCopter mini = GameManager.server.CreateEntity(_config.assetPrefab, GetIdealFixedPositionForPlayer(player), GetIdealRotationForPlayer(player)) as MiniCopter;
             if (mini == null) return;
 
             mini.OwnerID = player.userID;

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.7.0"), Description("Spawn a mini!")]
+    [Info("Spawn Mini", "SpooksAU", "2.8.0"), Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
         private SaveData _data;

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -280,21 +280,31 @@ namespace Oxide.Plugins
                 return;
             }
 
-            RaycastHit hit;
-            if (!Physics.Raycast(player.eyes.HeadRay(), out hit, Mathf.Infinity,
-                LayerMask.GetMask("Construction", "Default", "Deployed", "Resource", "Terrain", "Water", "World")))
+            Vector3 position;
+
+            if (_config.useFixedSpawnDistance)
             {
-                player.ChatMessage(lang.GetMessage("mini_terrain", this, player.UserIDString));
-                return;
+                position = GetIdealFixedPositionForPlayer(player);
+            }
+            else
+            {
+                RaycastHit hit;
+                if (!Physics.Raycast(player.eyes.HeadRay(), out hit, Mathf.Infinity,
+                    LayerMask.GetMask("Construction", "Default", "Deployed", "Resource", "Terrain", "Water", "World")))
+                {
+                    player.ChatMessage(lang.GetMessage("mini_terrain", this, player.UserIDString));
+                    return;
+                }
+
+                if (hit.distance > _config.maxSpawnDistance)
+                {
+                    player.ChatMessage(lang.GetMessage("mini_sdistance", this, player.UserIDString));
+                    return;
+                }
+
+                position = hit.point + Vector3.up * 2f;
             }
 
-            if (hit.distance > _config.maxSpawnDistance)
-            {
-                player.ChatMessage(lang.GetMessage("mini_sdistance", this, player.UserIDString));
-                return;
-            }
-
-            Vector3 position = hit.point + Vector3.up * 2f;
             MiniCopter mini = GameManager.server.CreateEntity(_config.assetPrefab, position, GetIdealRotationForPlayer(player)) as MiniCopter;
             if (mini == null) return;
 
@@ -411,6 +421,9 @@ namespace Oxide.Plugins
 
             [JsonProperty("MaxSpawnDistance")]
             public float maxSpawnDistance { get; set; }
+
+            [JsonProperty("UseFixedSpawnDistance")]
+            public bool useFixedSpawnDistance { get; set; }
 
             [JsonProperty("MaxNoMiniDistance")]
             public float noMiniDistance { get; set; }

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -180,7 +180,9 @@ namespace Oxide.Plugins
                     if (mini == null)
                         return;
 
-                    if (mini.AnyMounted())
+                    bool isMounted = mini.AnyMounted();
+
+                    if (isMounted && (!_config.CanFetchWhileOccupied || player.GetMountedVehicle() == mini))
                     {
                         player.ChatMessage(lang.GetMessage("mini_mounted", this, player.UserIDString));
                         return;
@@ -190,6 +192,13 @@ namespace Oxide.Plugins
                     {
                         player.ChatMessage(lang.GetMessage("mini_current_distance", this, player.UserIDString));
                         return;
+                    }
+
+                    if (isMounted)
+                    {
+                        // mini.DismountAllPlayers() doesn't work so we have to enumerate the mount points
+                        foreach (var mountPoint in mini.mountPoints)
+                            mountPoint.mountable?.DismountAllPlayers();
                     }
 
                     Puts(GetDistance(player, mini).ToString());
@@ -219,7 +228,7 @@ namespace Oxide.Plugins
                     if (mini == null)
                         return;
 
-                    if (mini.AnyMounted())
+                    if (mini.AnyMounted() && (!_config.CanDespawnWhileOccupied || player.GetMountedVehicle() == mini))
                     {
                         player.ChatMessage(lang.GetMessage("mini_mounted", this, player.UserIDString));
                         return;
@@ -421,6 +430,12 @@ namespace Oxide.Plugins
             [JsonProperty("CanSpawnBuildingBlocked")]
             public bool canSpawnBuildingBlocked { get; set; }
 
+            [JsonProperty("CanDespawnWhileOccupied")]
+            public bool CanDespawnWhileOccupied { get; set; }
+
+            [JsonProperty("CanFetchWhileOccupied")]
+            public bool CanFetchWhileOccupied { get; set; }
+
             [JsonProperty("PermissionCooldowns")]
             public Dictionary<string, float> cooldowns { get; set; }
 
@@ -437,6 +452,8 @@ namespace Oxide.Plugins
                 noMiniDistance = 300f,
                 assetPrefab = "assets/content/vehicles/minicopter/minicopter.entity.prefab",
                 canSpawnBuildingBlocked = false,
+                CanDespawnWhileOccupied = false,
+                CanFetchWhileOccupied = false,
                 ownerOnly = false,
                 cooldowns = new Dictionary<string, float>()
                 {

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -201,9 +201,7 @@ namespace Oxide.Plugins
                     mountPoint.mountable?.DismountAllPlayers();
             }
 
-            Puts(GetDistance(player, mini).ToString());
-            Vector3 destination = new Vector3(player.transform.position.x, player.transform.position.y + 3.5f, player.transform.position.z + 2);
-            mini.transform.position = destination;
+            mini.transform.SetPositionAndRotation(GetIdealFixedPositionForPlayer(player), GetIdealRotationForPlayer(player));
         }
 
         [ChatCommand("nomini")]
@@ -264,6 +262,12 @@ namespace Oxide.Plugins
 
         private bool IsMiniBeyondMaxDistance(BasePlayer player, MiniCopter mini) =>
             _config.noMiniDistance >= 0 && GetDistance(player, mini) > _config.noMiniDistance;
+
+        private Vector3 GetIdealFixedPositionForPlayer(BasePlayer player)
+        {
+            Vector3 forward = player.GetNetworkRotation() * Vector3.forward;
+            return player.transform.position + forward.normalized * 3f + Vector3.up * 2f;
+        }
 
         private Quaternion GetIdealRotationForPlayer(BasePlayer player) =>
             Quaternion.Euler(0, player.GetNetworkRotation().eulerAngles.y - 135, 0);

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -182,7 +182,7 @@ namespace Oxide.Plugins
 
             bool isMounted = mini.AnyMounted();
 
-            if (isMounted && (!_config.CanFetchWhileOccupied || player.GetMountedVehicle() == mini))
+            if (isMounted && (!_config.canFetchWhileOccupied || player.GetMountedVehicle() == mini))
             {
                 player.ChatMessage(lang.GetMessage("mini_mounted", this, player.UserIDString));
                 return;
@@ -224,7 +224,7 @@ namespace Oxide.Plugins
             if (mini == null)
                 return;
 
-            if (mini.AnyMounted() && (!_config.CanDespawnWhileOccupied || player.GetMountedVehicle() == mini))
+            if (mini.AnyMounted() && (!_config.canDespawnWhileOccupied || player.GetMountedVehicle() == mini))
             {
                 player.ChatMessage(lang.GetMessage("mini_mounted", this, player.UserIDString));
                 return;
@@ -361,10 +361,10 @@ namespace Oxide.Plugins
 
         private void AddInitialFuel(MiniCopter minicopter)
         {
-            if (_config.FuelAmount == 0) return;
+            if (_config.fuelAmount == 0) return;
 
             StorageContainer fuelContainer = minicopter.GetFuelSystem().GetFuelContainer();
-            int fuelAmount = _config.FuelAmount < 0 ? fuelContainer.allowedItem.stackable : _config.FuelAmount;
+            int fuelAmount = _config.fuelAmount < 0 ? fuelContainer.allowedItem.stackable : _config.fuelAmount;
             fuelContainer.inventory.AddItem(fuelContainer.allowedItem, fuelAmount);
         }
 
@@ -422,16 +422,16 @@ namespace Oxide.Plugins
             public bool canSpawnBuildingBlocked { get; set; }
 
             [JsonProperty("CanDespawnWhileOccupied")]
-            public bool CanDespawnWhileOccupied { get; set; }
+            public bool canDespawnWhileOccupied { get; set; }
 
             [JsonProperty("CanFetchWhileOccupied")]
-            public bool CanFetchWhileOccupied { get; set; }
+            public bool canFetchWhileOccupied { get; set; }
 
             [JsonProperty("PermissionCooldowns")]
             public Dictionary<string, float> cooldowns { get; set; }
 
             [JsonProperty("FuelAmount")]
-            public int FuelAmount { get; set; }
+            public int fuelAmount { get; set; }
 
             [JsonProperty("OwnerAndTeamCanMount")]
             public bool ownerOnly { get; set; }
@@ -446,9 +446,9 @@ namespace Oxide.Plugins
                 noMiniDistance = 300f,
                 assetPrefab = "assets/content/vehicles/minicopter/minicopter.entity.prefab",
                 canSpawnBuildingBlocked = false,
-                CanDespawnWhileOccupied = false,
-                CanFetchWhileOccupied = false,
-                FuelAmount = 0,
+                canDespawnWhileOccupied = false,
+                canFetchWhileOccupied = false,
+                fuelAmount = 0,
                 ownerOnly = false,
                 cooldowns = new Dictionary<string, float>()
                 {


### PR DESCRIPTION
The commits describe everything in sufficient detail, but below are the recommended patch notes to paste into uMod after merging.

- Added  `CanDespawnWhileOccupied` and `CanFetchWhileOccupied` config options to allow the player to use `/nomini` and `/fmini` while their mini is mounted
- Added `FuelAmount`  config option to determine how much low grade fuel minicopters should spawn with (does not affect minis spawned for players that have the  `spawnmini.unlimitedfuel` permission)
- Updated the `/fmini` command to teleport the mini in front of the player instead of on top of them. This also spawns it lower to the ground to reduce the likelihood of it taking damage when hitting the ground
- Updated the `spawnmini.give` command to spawn the mini closer to the player (same position as `/fmini`)
- Added `UseFixedSpawnDistance` config option to allow minis to be spawned at a fixed distance in front of the player instead of spawning where the player is looking (uses the same positioning as `/fmini` and `spawnmini.give`)
- Improved cooldown display and fixed an issue where updating cooldown permissions wouldn't update players' current cooldowns. **While upgrading, players with active cooldowns may have their cooldowns extended a bit but this is a one time thing.** You can mitigate this by resetting the plugin data while upgrading to the new version. To do this, first unload the plugin, delete the plugin's data file, then load the plugin. Note that resetting the data this way will also unregister any currently spawned minis, so while players can spawn new ones, there may end up being a few bonus minis around.