### PR TITLE
Fix hook conflict with no decay and prevent OwnerAndTeamCanMount from affecting other minicopters

### DIFF
--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.8.1"), Description("Spawn a mini!")]
+    [Info("Spawn Mini", "SpooksAU", "2.8.2"), Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
         private SaveData _data;
@@ -101,7 +101,7 @@ namespace Oxide.Plugins
                 return null;
 
             var mini = entity.GetVehicleParent() as MiniCopter;
-            if (mini == null || mini is ScrapTransportHelicopter || mini.OwnerID == 0) return null;
+            if (mini == null || mini is ScrapTransportHelicopter || mini.OwnerID == 0 || !IsPlayerOwned(mini)) return null;
 
             if (mini.OwnerID != player.userID)
             {

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -90,7 +90,7 @@ namespace Oxide.Plugins
 
             if (_data.playerMini.ContainsValue(entity.net.ID))
                 if (permission.UserHasPermission(entity.OwnerID.ToString(), _noDecay) && info.damageTypes.Has(Rust.DamageType.Decay))
-                    return false;
+                    return true;
 
             return null;
         }


### PR DESCRIPTION
Hook conflict with no decay was reported here:
https://umod.org/community/spawn-mini/23181-calling-hook-onentitytakedamage-resulted-in-a-conflict