### PR TITLE
Save data when server saves

### DIFF
--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -7,7 +7,7 @@ using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.8.2"), Description("Spawn a mini!")]
+    [Info("Spawn Mini", "SpooksAU", "2.8.3"), Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
         private SaveData _data;
@@ -58,6 +58,8 @@ namespace Oxide.Plugins
         }
 
         void Unload() => WriteSaveData();
+
+        void OnServerSave() => WriteSaveData();
 
         void OnNewSave()
         {


### PR DESCRIPTION
This fixes an issue where player minis could be forgotten on server restart, which would also break the ones with unlimited fuel.

https://umod.org/community/spawn-mini/26249-players-spawning-minicopters-again-when-old-ones-do-not-work