### PR TITLE
Add DestroyOnDisconnect and DefaultCooldown config options

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ Default configuration:
     "spawnmini.tier2": 21600.0,
     "spawnmini.tier3": 10800.0
   },
-  "SpawnHealth": 750.0
+  "SpawnHealth": 750.0,
+  "DestroyOnDisconnect": false
 }
 ```
 
@@ -64,6 +65,7 @@ Options explained:
   * If a player has no cooldown permissions, `DefaultCooldown` will be used for them.
   * You can add as many cooldown tiers as you would like, but you should prefix them all with `spawnmini.` to prevent warnings in the server logs.
 * `SpawnHealth` -- The health minicopters will spawn with.
+* `DestroyOnDisconnect` (`true` or `false`) -- Set to `true` to destroy each spawned minicopter when its owner disconnects from the server. If the minicopter is mounted, it will be destroyed when fully dismounted.
 
 ## Localization
 

--- a/README.md
+++ b/README.md
@@ -37,31 +37,31 @@ Default configuration:
   "FuelAmount": 0,
   "MaxNoMiniDistance": 300.0,
   "MaxSpawnDistance": 5.0,
+  "UseFixedSpawnDistance": false,
   "OwnerAndTeamCanMount": false,
   "PermissionCooldowns": {
     "spawnmini.tier1": 86400.0,
     "spawnmini.tier2": 43200.0,
     "spawnmini.tier3": 21600.0
   },
-  "SpawnHealth": 750.0,
-  "UseFixedSpawnDistance": false
+  "SpawnHealth": 750.0
 }
 ```
 
 Options explained:
-* `CanDespawnWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/nomini` while their minicopter is mounted. Regardless of this setting, players cannot despawn their minicopter while they mounted on it.
+* `CanDespawnWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/nomini` while their minicopter is mounted. Regardless of this setting, players cannot despawn their minicopter while they are mounted on it.
 * `CanFetchWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/fmini` while the minicopter is mounted. Mounted players will be dismounted automatically. Regardless of this setting, players cannot fetched their minicopter while they are mounted on it.
 * `CanSpawnBuildingBlocked` (`true` or `false`) -- Whether to allow players to spawn a minicopter while building blocked.
 * `FuelAmount` -- Amount of low grade fuel to add to minicopters when spawned. Set to `-1` for max stack size (which depends on the server, but is 500 in vanilla). Does not apply to minicopters spawned for players who have the `spawnmini.unlimitedfuel` permission.
 * `MaxNoMiniDistance` -- The maximum distance players can be from their minicopter to use `/nomini` or `/fmini`. Set to `-1` to allow those commands at unlimited distance.
 * `MaxSpawnDistance` -- The maximum distance away that players are allowed to spawn their minicopter.
+* `UseFixedSpawnDistance` (`true` or `false`) -- Set to `true` to cause minicopters to spawn directly in front of players at a fixed distance, disregarding the `MaxSpawnDistance` setting. Performs no terrain checks.
 * `OwnerAndTeamCanMount` (`true` or `false`) -- Set to `true` to only allow the owner and their team members to be able to mount the minicopter.
 * `PermissionCooldowns` -- Use these settings to customize cooldowns for different player groups. For example, set `"spawnmini.tier1": 3600.0` and then grant the `spawnmini.tier1` permission to a group of players to assign them a 1 hour cooldown for spawning their minicopters.
   * If a player has multiple cooldown permissions, the lowest is used.
   * If a player has no cooldown permissions, their cooldown will be 1 day.
   * You can add as many cooldown tiers as you would like, but you should prefix them all with `spawnmini` to prevent warnings in the server logs.
 * `SpawnHealth` -- The health minicopters will spawn with.
-* `UseFixedSpawnDistance` (`true` or `false`) -- Set to `true` to cause minicopters to spawn directly in front of players at a fixed distance, disregarding the `MaxSpawnDistance` setting. Performs no terrain checks.
 
 ## Localization
 

--- a/README.md
+++ b/README.md
@@ -39,10 +39,11 @@ Default configuration:
   "MaxSpawnDistance": 5.0,
   "UseFixedSpawnDistance": false,
   "OwnerAndTeamCanMount": false,
+  "DefaultCooldown": 86400.0,
   "PermissionCooldowns": {
-    "spawnmini.tier1": 86400.0,
-    "spawnmini.tier2": 43200.0,
-    "spawnmini.tier3": 21600.0
+    "spawnmini.tier1": 43200.0,
+    "spawnmini.tier2": 21600.0,
+    "spawnmini.tier3": 10800.0
   },
   "SpawnHealth": 750.0
 }
@@ -57,10 +58,11 @@ Options explained:
 * `MaxSpawnDistance` -- The maximum distance away that players are allowed to spawn their minicopter.
 * `UseFixedSpawnDistance` (`true` or `false`) -- Set to `true` to cause minicopters to spawn directly in front of players at a fixed distance, disregarding the `MaxSpawnDistance` setting. Performs no terrain checks.
 * `OwnerAndTeamCanMount` (`true` or `false`) -- Set to `true` to only allow the owner and their team members to be able to mount the minicopter.
+* `DefaultCooldown` -- The default spawn cooldown that will apply to players who have not been granted any permissions in `PermissionCooldowns`.
 * `PermissionCooldowns` -- Use these settings to customize cooldowns for different player groups. For example, set `"spawnmini.tier1": 3600.0` and then grant the `spawnmini.tier1` permission to a group of players to assign them a 1 hour cooldown for spawning their minicopters.
   * If a player has multiple cooldown permissions, the lowest is used.
-  * If a player has no cooldown permissions, their cooldown will be 1 day.
-  * You can add as many cooldown tiers as you would like, but you should prefix them all with `spawnmini` to prevent warnings in the server logs.
+  * If a player has no cooldown permissions, `DefaultCooldown` will be used for them.
+  * You can add as many cooldown tiers as you would like, but you should prefix them all with `spawnmini.` to prevent warnings in the server logs.
 * `SpawnHealth` -- The health minicopters will spawn with.
 
 ## Localization

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.8.3"), Description("Spawn a mini!")]
+    [Info("Spawn Mini", "SpooksAU", "2.9.0"), Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
         private SaveData _data;

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -1,9 +1,11 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Newtonsoft.Json.Serialization;
 using Oxide.Core;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
-using Newtonsoft.Json;
 
 namespace Oxide.Plugins
 {
@@ -25,8 +27,6 @@ namespace Oxide.Plugins
 
         private void Init()
         {
-            _config = Config.ReadObject<PluginConfig>();
-
             permission.RegisterPermission(_spawnMini, this);
             permission.RegisterPermission(_noCooldown, this);
             permission.RegisterPermission(_noMini, this);
@@ -404,7 +404,7 @@ namespace Oxide.Plugins
 
         #endregion
 
-        #region Classes And Overrides
+        #region Data & Configuration
 
         private void WriteSaveData() =>
             Interface.Oxide.DataFileSystem.WriteObject(Name, _data);
@@ -415,68 +415,52 @@ namespace Oxide.Plugins
             public Dictionary<string, DateTime> cooldown = new Dictionary<string, DateTime>();
         }
 
-        class PluginConfig
+        class PluginConfig : SerializableConfiguration
         {
             [JsonProperty("AssetPrefab")]
-            public string assetPrefab { get; set; }
-
-            [JsonProperty("MaxSpawnDistance")]
-            public float maxSpawnDistance { get; set; }
-
-            [JsonProperty("UseFixedSpawnDistance")]
-            public bool useFixedSpawnDistance { get; set; }
-
-            [JsonProperty("MaxNoMiniDistance")]
-            public float noMiniDistance { get; set; }
-
-            [JsonProperty("SpawnHealth")]
-            public float spawnHealth { get; set; }
-
-            [JsonProperty("CanSpawnBuildingBlocked")]
-            public bool canSpawnBuildingBlocked { get; set; }
+            public string assetPrefab = "assets/content/vehicles/minicopter/minicopter.entity.prefab";
 
             [JsonProperty("CanDespawnWhileOccupied")]
-            public bool canDespawnWhileOccupied { get; set; }
+            public bool canDespawnWhileOccupied = false;
 
             [JsonProperty("CanFetchWhileOccupied")]
-            public bool canFetchWhileOccupied { get; set; }
+            public bool canFetchWhileOccupied = false;
 
-            [JsonProperty("PermissionCooldowns")]
-            public Dictionary<string, float> cooldowns { get; set; }
+            [JsonProperty("CanSpawnBuildingBlocked")]
+            public bool canSpawnBuildingBlocked = false;
 
             [JsonProperty("FuelAmount")]
-            public int fuelAmount { get; set; }
+            public int fuelAmount = 0;
+
+            [JsonProperty("MaxNoMiniDistance")]
+            public float noMiniDistance = 300f;
+
+            [JsonProperty("MaxSpawnDistance")]
+            public float maxSpawnDistance = 5f;
+
+            [JsonProperty("UseFixedSpawnDistance")]
+            public bool useFixedSpawnDistance = false;
 
             [JsonProperty("OwnerAndTeamCanMount")]
-            public bool ownerOnly { get; set; }
-        }
+            public bool ownerOnly = false;
 
-        private PluginConfig GetDefaultConfig()
-        {
-            return new PluginConfig
+            [JsonProperty("PermissionCooldowns")]
+            public Dictionary<string, float> cooldowns = new Dictionary<string, float>()
             {
-                maxSpawnDistance = 5f,
-                spawnHealth = 750f,
-                noMiniDistance = 300f,
-                assetPrefab = "assets/content/vehicles/minicopter/minicopter.entity.prefab",
-                canSpawnBuildingBlocked = false,
-                canDespawnWhileOccupied = false,
-                canFetchWhileOccupied = false,
-                fuelAmount = 0,
-                ownerOnly = false,
-                cooldowns = new Dictionary<string, float>()
-                {
-                    ["spawnmini.tier1"] = 86400f,
-                    ["spawnmini.tier2"] = 43200f,
-                    ["spawnmini.tier3"] = 21600f,
-                }
+                ["spawnmini.tier1"] = 86400f,
+                ["spawnmini.tier2"] = 43200f,
+                ["spawnmini.tier3"] = 21600f,
             };
+
+            [JsonProperty("SpawnHealth")]
+            public float spawnHealth = 750f;
         }
 
-        protected override void LoadDefaultConfig()
-        {
-            Config.WriteObject(GetDefaultConfig(), true);
-        }
+        private PluginConfig GetDefaultConfig() => new PluginConfig();
+
+        #endregion
+
+        #region Localization
 
         protected override void LoadDefaultMessages()
         {
@@ -525,6 +509,110 @@ namespace Oxide.Plugins
                 ["mini_rcon"] = "Dieser Befehl kann nur von RCON ausgeführt werden!",
                 ["mini_canmount"] = "Sie sind nicht der Besitzer dieses Minicopters oder im Team des Besitzers!"
             }, this, "de");
+        }
+
+        #endregion
+
+        #region Configuration Boilerplate
+
+        internal class SerializableConfiguration
+        {
+            public string ToJson() => JsonConvert.SerializeObject(this);
+
+            public Dictionary<string, object> ToDictionary() => JsonHelper.Deserialize(ToJson()) as Dictionary<string, object>;
+        }
+
+        internal static class JsonHelper
+        {
+            public static object Deserialize(string json) => ToObject(JToken.Parse(json));
+
+            private static object ToObject(JToken token)
+            {
+                switch (token.Type)
+                {
+                    case JTokenType.Object:
+                        return token.Children<JProperty>()
+                                    .ToDictionary(prop => prop.Name,
+                                                  prop => ToObject(prop.Value));
+
+                    case JTokenType.Array:
+                        return token.Select(ToObject).ToList();
+
+                    default:
+                        return ((JValue)token).Value;
+                }
+            }
+        }
+
+        private bool MaybeUpdateConfig(SerializableConfiguration config)
+        {
+            var currentWithDefaults = config.ToDictionary();
+            var currentRaw = Config.ToDictionary(x => x.Key, x => x.Value);
+            return MaybeUpdateConfigDict(currentWithDefaults, currentRaw);
+        }
+
+        private bool MaybeUpdateConfigDict(Dictionary<string, object> currentWithDefaults, Dictionary<string, object> currentRaw)
+        {
+            bool changed = false;
+
+            foreach (var key in currentWithDefaults.Keys)
+            {
+                object currentRawValue;
+                if (currentRaw.TryGetValue(key, out currentRawValue))
+                {
+                    var defaultDictValue = currentWithDefaults[key] as Dictionary<string, object>;
+                    var currentDictValue = currentRawValue as Dictionary<string, object>;
+
+                    if (defaultDictValue != null)
+                    {
+                        // Don't update nested keys since the cooldown tiers might be customized
+                        if (currentDictValue == null)
+                        {
+                            currentRaw[key] = currentWithDefaults[key];
+                            changed = true;
+                        }
+                    }
+                }
+                else
+                {
+                    currentRaw[key] = currentWithDefaults[key];
+                    changed = true;
+                }
+            }
+
+            return changed;
+        }
+
+        protected override void LoadDefaultConfig() => _config = GetDefaultConfig();
+
+        protected override void LoadConfig()
+        {
+            base.LoadConfig();
+            try
+            {
+                _config = Config.ReadObject<PluginConfig>();
+                if (_config == null)
+                {
+                    throw new JsonException();
+                }
+
+                if (MaybeUpdateConfig(_config))
+                {
+                    PrintWarning("Configuration appears to be outdated; updating and saving");
+                    SaveConfig();
+                }
+            }
+            catch
+            {
+                PrintWarning($"Configuration file {Name}.json is invalid; using defaults");
+                LoadDefaultConfig();
+            }
+        }
+
+        protected override void SaveConfig()
+        {
+            Puts($"Configuration changes saved to {Name}.json");
+            Config.WriteObject(_config, true);
         }
 
         #endregion

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -367,7 +367,7 @@ namespace Oxide.Plugins
                 .Where(entry => permission.UserHasPermission(player.UserIDString, entry.Key));
 
             // Default cooldown to 1 day if they don't have any specific permissions
-            return grantedCooldownPerms.Any() ? grantedCooldownPerms.Min(entry => entry.Value) : 86400;
+            return grantedCooldownPerms.Any() ? grantedCooldownPerms.Min(entry => entry.Value) : _config.defaultCooldown;
         }
 
         private void AddInitialFuel(MiniCopter minicopter)
@@ -444,12 +444,15 @@ namespace Oxide.Plugins
             [JsonProperty("OwnerAndTeamCanMount")]
             public bool ownerOnly = false;
 
+            [JsonProperty("DefaultCooldown")]
+            public float defaultCooldown = 86400f;
+
             [JsonProperty("PermissionCooldowns")]
             public Dictionary<string, float> cooldowns = new Dictionary<string, float>()
             {
-                ["spawnmini.tier1"] = 86400f,
-                ["spawnmini.tier2"] = 43200f,
-                ["spawnmini.tier3"] = 21600f,
+                ["spawnmini.tier1"] = 43200f,
+                ["spawnmini.tier2"] = 21600f,
+                ["spawnmini.tier3"] = 10800f,
             };
 
             [JsonProperty("SpawnHealth")]


### PR DESCRIPTION
- Added `DestroyOnDisconnect` config option which will cause player spawned minis to be destroyed when the owner disconnects, or when all players eventually dismount while the owner is disconnected - [Requested by Nexux](https://umod.org/community/spawn-mini/27137-good-afternoon-good-offer)
- Added the `DefaultCooldown` config option so the default spawn cooldown can be changed from the previously hard-coded value of 1 day - [Requested by razorfishsl](https://umod.org/community/spawn-mini/27190-remove-the-time-set-to-24-hours)
- Changed default `PermissionCooldowns` values for new users of the plugin, so they don't overlap with the `DefaultCooldown`
- Changed config loading behavior so new config options will be added automatically with their default values