### PR TITLE
Bug fix, hooks, and default config changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,29 @@ Spawn Mini supports English, Russian, and German; and you can also add more lang
 
 If you have any ideas/suggestions I would love to hear them. If you have any issues use the Plugin Support section.
 
+## Developer Hooks
+
+```csharp
+object OnMyMiniSpawn(BasePlayer player)
+```
+- Called when a player uses `/mymini`
+- Returning `false` will prevent spawning the minicopter
+- Returning `null` will result in the default behavior
+
+```csharp
+object OnMyMiniFetch(BasePlayer player, MiniCopter mini)
+```
+- Called when a player uses `/fmini`
+- Returning `false` will prevent fetching the minicopter
+- Returning `null` will result in the default behavior
+
+```csharp
+object OnMyMiniDespawn(BasePlayer player, MiniCopter mini)
+```
+- Called when a player uses `/nomini`
+- Returning `false` will prevent despawning the minicopter
+- Returning `null` will result in the default behavior
+
 ## Credits
 
 * **SpooksAU**, the current maintainer

--- a/README.md
+++ b/README.md
@@ -36,9 +36,9 @@ Default configuration:
   "CanFetchWhileOccupied": false,
   "CanSpawnBuildingBlocked": false,
   "FuelAmount": 0,
-  "MaxNoMiniDistance": 300.0,
+  "MaxNoMiniDistance": -1.0,
   "MaxSpawnDistance": 5.0,
-  "UseFixedSpawnDistance": false,
+  "UseFixedSpawnDistance": true,
   "OwnerAndTeamCanMount": false,
   "DefaultCooldown": 86400.0,
   "PermissionCooldowns": {

--- a/README.md
+++ b/README.md
@@ -15,12 +15,13 @@
 
 ## Server Commands
 
-* `spawnmini.give <steamid or name>` -- Spawn a minicopter for a specific player
+* `spawnmini.give <name or steamid>` -- Spawn a minicopter for a specific player using their name or steamid64
+* `spawnmini.give <name or steamid> <x> <y> <z>` -- Spawn a minicopter for a specific player at the designated coordinates
 
 ## For Developers
 
 ```csharp
-void SpawnMinicopter(BasePlayer/string);
+void SpawnMinicopter(BasePlayer);
 float GetDistance(BasePlayer, MiniCopter);
 bool IsPlayerOwned(MiniCopter);
 ```

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -181,6 +181,9 @@ namespace Oxide.Plugins
                 return;
             }
 
+            if (SpawnWasBlocked(player))
+                return;
+
             if (_data.cooldown.ContainsKey(player.UserIDString) && !permission.UserHasPermission(player.UserIDString, _noCooldown))
             {
                 DateTime lastSpawned = _data.cooldown[player.UserIDString];
@@ -226,6 +229,9 @@ namespace Oxide.Plugins
                 return;
             }
 
+            if (FetchWasBlocked(player, mini))
+                return;
+
             if (isMounted)
             {
                 // mini.DismountAllPlayers() doesn't work so we have to enumerate the mount points
@@ -264,6 +270,9 @@ namespace Oxide.Plugins
                 return;
             }
 
+            if (DespawnWasBlocked(player, mini))
+                return;
+
             BaseNetworkable.serverEntities.Find(_data.playerMini[player.UserIDString])?.Kill();
         }
 
@@ -287,6 +296,24 @@ namespace Oxide.Plugins
         #endregion
 
         #region Helpers/Functions
+
+        private bool SpawnWasBlocked(BasePlayer player)
+        {
+            object hookResult = Interface.CallHook("OnMyMiniSpawn", player);
+            return hookResult is bool && (bool)hookResult == false;
+        }
+
+        private bool FetchWasBlocked(BasePlayer player, MiniCopter mini)
+        {
+            object hookResult = Interface.CallHook("OnMyMiniFetch", player, mini);
+            return hookResult is bool && (bool)hookResult == false;
+        }
+
+        private bool DespawnWasBlocked(BasePlayer player, MiniCopter mini)
+        {
+            object hookResult = Interface.CallHook("OnMyMiniDespawn", player, mini);
+            return hookResult is bool && (bool)hookResult == false;
+        }
 
         private TimeSpan CeilingTimeSpan(TimeSpan timeSpan) =>
             new TimeSpan((long)Math.Ceiling(1.0 * timeSpan.Ticks / 10000000) * 10000000);

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -523,13 +523,13 @@ namespace Oxide.Plugins
             public int fuelAmount = 0;
 
             [JsonProperty("MaxNoMiniDistance")]
-            public float noMiniDistance = 300f;
+            public float noMiniDistance = -1;
 
             [JsonProperty("MaxSpawnDistance")]
             public float maxSpawnDistance = 5f;
 
             [JsonProperty("UseFixedSpawnDistance")]
-            public bool useFixedSpawnDistance = false;
+            public bool useFixedSpawnDistance = true;
 
             [JsonProperty("OwnerAndTeamCanMount")]
             public bool ownerOnly = false;

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.9.0"), Description("Spawn a mini!")]
+    [Info("Spawn Mini", "SpooksAU", "2.10.0"), Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
         private SaveData _data;


### PR DESCRIPTION
- Fixed bug where `/fmini` and `/nomini` would do nothing if the plugin's data file was out of sync
- Updated configuration option `MaxNoMiniDistance` to default to `-1.0` (no maximum) for new installations since this option tends to confuse people
- Updated configuration option `UseFixedSpawnDistance` to default to `true` since it tends to be more user-friendly
- Added variant of the `spawnmini.give` server command that supports coordinates: `spawnmini.give <name or steamid> <x> <y> <z>`
- Improved error handling feedback for `spawnmini.give`

For developers:
- Added hooks to allow blocking player commands: `OnMyMiniSpawn`, `OnMyMiniFetch`, and `OnMyMiniDespawn`
- Removed the `SpawnMinicopter(string)` API method overload since other plugins can easily provide the `BasePlayer` instead