### PR TITLE
Fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Default configuration:
   "CanDespawnWhileOccupied": false,
   "CanFetchWhileOccupied": false,
   "CanSpawnBuildingBlocked": false,
+  "CanFetchBuildingBlocked": true,
   "FuelAmount": 0,
   "FuelAmountsRequiringPermission": [],
   "MaxNoMiniDistance": -1.0,
@@ -58,6 +59,7 @@ Options explained:
 * `CanDespawnWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/nomini` while their minicopter is mounted. Regardless of this setting, players cannot despawn their minicopter while they are mounted on it.
 * `CanFetchWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/fmini` while the minicopter is mounted. Mounted players will be dismounted automatically. Regardless of this setting, players cannot fetched their minicopter while they are mounted on it.
 * `CanSpawnBuildingBlocked` (`true` or `false`) -- Whether to allow players to spawn a minicopter while building blocked.
+* `CanFetchBuildingBlocked` (`true` or `false`) -- Whether to allow players to use `/fmini` while building blocked.
 * `FuelAmount` -- Amount of low grade fuel to add to minicopters when spawned. Set to `-1` for max stack size (which depends on the server, but is 500 in vanilla). Does not apply to minicopters spawned for players who have the `spawnmini.unlimitedfuel` permission.
 * `FuelAmountsRequiringPermission` -- Use this to customize the fuel amount for different player groups. Simply add the desire fuel amounts like `[100, 200]`, and reload the plugin to generate permissions of the format `spawnmini.fuel.<amount>`. Granting one to a player will cause their mini to spawn with that amount of low grade fuel, overriding the default `FuelAmount`. If you grant multiple of these permission to a player, the last will apply, based on the order in the config.
 * `MaxNoMiniDistance` -- The maximum distance players can be from their minicopter to use `/nomini` or `/fmini`. Set to `-1` to allow those commands at unlimited distance.

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Options explained:
 
 ## Localization
 
-Spawn Mini supports English, Russian, and German; and you can also add more languages.
+Spawn Mini comes bundled with partial translations for Russian and German which were contributed by the community. Please open a thread in the help section if you would like to contribute translations.
 
 ## Future Plans
 

--- a/README.md
+++ b/README.md
@@ -2,10 +2,12 @@
 
 * `spawnmini.mini`  -- Allows player to spawn a minicopter with `/mymini`
 * `spawnmini.nocd` -- Gives player no cooldown for `/mymini` chat command
-* `spawnmini.nomini` -- Allows player to use `/nomini` chat command 
+* `spawnmini.nomini` -- Allows player to use `/nomini` chat command
 * `spawnmini.nodecay` -- Doesn't allow the player's minicopter to decay
 * `spawnmini.unlimitedfuel` -- Gives the player unlimited fuel when they spawn their minicopter
 * `spawnmini.fmini` -- Allows player to use `/fmini` chat command
+* `spawnmini.fuel.<amount>` -- Determines the amount of fuel the player's minicopter spawns with, overriding the `FuelAmount` config value
+  * To use this, you must first add the desired amount in the `FuelAmountsRequiringPermission` config option
 
 ## Chat Commands
 
@@ -36,6 +38,7 @@ Default configuration:
   "CanFetchWhileOccupied": false,
   "CanSpawnBuildingBlocked": false,
   "FuelAmount": 0,
+  "FuelAmountsRequiringPermission": [],
   "MaxNoMiniDistance": -1.0,
   "MaxSpawnDistance": 5.0,
   "UseFixedSpawnDistance": true,
@@ -56,6 +59,7 @@ Options explained:
 * `CanFetchWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/fmini` while the minicopter is mounted. Mounted players will be dismounted automatically. Regardless of this setting, players cannot fetched their minicopter while they are mounted on it.
 * `CanSpawnBuildingBlocked` (`true` or `false`) -- Whether to allow players to spawn a minicopter while building blocked.
 * `FuelAmount` -- Amount of low grade fuel to add to minicopters when spawned. Set to `-1` for max stack size (which depends on the server, but is 500 in vanilla). Does not apply to minicopters spawned for players who have the `spawnmini.unlimitedfuel` permission.
+* `FuelAmountsRequiringPermission` -- Use this to customize the fuel amount for different player groups. Simply add the desire fuel amounts like `[100, 200]`, and reload the plugin to generate permissions of the format `spawnmini.fuel.<amount>`. Granting one to a player will cause their mini to spawn with that amount of low grade fuel, overriding the default `FuelAmount`. If you grant multiple of these permission to a player, the last will apply, based on the order in the config.
 * `MaxNoMiniDistance` -- The maximum distance players can be from their minicopter to use `/nomini` or `/fmini`. Set to `-1` to allow those commands at unlimited distance.
 * `MaxSpawnDistance` -- The maximum distance away that players are allowed to spawn their minicopter.
 * `UseFixedSpawnDistance` (`true` or `false`) -- Set to `true` to cause minicopters to spawn directly in front of players at a fixed distance, disregarding the `MaxSpawnDistance` setting. Performs no terrain checks.

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -199,6 +199,12 @@ namespace Oxide.Plugins
                 return;
             }
 
+            if (IsLocationRestricted(player.transform.position))
+            {
+                player.ChatMessage(lang.GetMessage("mini_location_restricted", this, player.UserIDString));
+                return;
+            }
+
             if (SpawnWasBlocked(player))
                 return;
 
@@ -244,6 +250,12 @@ namespace Oxide.Plugins
             if (IsMiniBeyondMaxDistance(player, mini))
             {
                 player.ChatMessage(lang.GetMessage("mini_current_distance", this, player.UserIDString));
+                return;
+            }
+
+            if (IsLocationRestricted(player.transform.position))
+            {
+                player.ChatMessage(lang.GetMessage("mini_location_restricted", this, player.UserIDString));
                 return;
             }
 
@@ -358,6 +370,12 @@ namespace Oxide.Plugins
 
         private TimeSpan CeilingTimeSpan(TimeSpan timeSpan) =>
             new TimeSpan((long)Math.Ceiling(1.0 * timeSpan.Ticks / 10000000) * 10000000);
+
+        private bool IsLocationRestricted(Vector3 position)
+        {
+            // Disallow spawning in underground train tunnels
+            return position.y < -100;
+        }
 
         private bool IsMiniBeyondMaxDistance(BasePlayer player, MiniCopter mini) =>
             _config.noMiniDistance >= 0 && GetDistance(player, mini) > _config.noMiniDistance;
@@ -630,6 +648,7 @@ namespace Oxide.Plugins
                 ["mini_current_distance"] = "The minicopter is too far!",
                 ["mini_canmount"] = "You are not the owner of this Minicopter or in the owner's team!",
                 ["mini_unlimited_fuel"] = "That minicopter doesn't need fuel!",
+                ["mini_location_restricted"] = "You cannot do that here!",
             }, this, "en");
             lang.RegisterMessages(new Dictionary<string, string>
             {

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -163,6 +163,19 @@ namespace Oxide.Plugins
                 mini.Kill();
         }
 
+        void CanLootEntity(BasePlayer player, StorageContainer container)
+        {
+            if (container == null || !container.IsLocked())
+                return;
+
+            var mini = container.GetParentEntity() as MiniCopter;
+            if (mini == null || !IsPlayerOwned(mini))
+                return;
+
+            if (permission.UserHasPermission(mini.OwnerID.ToString(), _noFuel))
+                player.ChatMessage(lang.GetMessage("mini_unlimited_fuel", this, player.UserIDString));
+        }
+
         #endregion
 
         #region Commands
@@ -585,7 +598,8 @@ namespace Oxide.Plugins
                 ["mini_terrain"] = "Trying to spawn minicopter outside of terrain!",
                 ["mini_mounted"] = "A player is currenty mounted on the minicopter!",
                 ["mini_current_distance"] = "The minicopter is too far!",
-                ["mini_canmount"] = "You are not the owner of this Minicopter or in the owner's team!"
+                ["mini_canmount"] = "You are not the owner of this Minicopter or in the owner's team!",
+                ["mini_unlimited_fuel"] = "That minicopter doesn't need fuel!",
             }, this, "en");
             lang.RegisterMessages(new Dictionary<string, string>
             {

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.10.0"), Description("Spawn a mini!")]
+    [Info("Spawn Mini", "SpooksAU", "2.11.0"), Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
         private SaveData _data;

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -240,6 +240,12 @@ namespace Oxide.Plugins
                 return;
             }
 
+            if (!_config.canFetchBuildlingBlocked && player.IsBuildingBlocked())
+            {
+                player.ChatMessage(lang.GetMessage("mini_buildingblocked", this, player.UserIDString));
+                return;
+            }
+
             bool isMounted = mini.AnyMounted();
             if (isMounted && (!_config.canFetchWhileOccupied || player.GetMountedVehicle() == mini))
             {
@@ -410,9 +416,9 @@ namespace Oxide.Plugins
 
         private void SpawnMinicopter(BasePlayer player)
         {
-            if (player.IsBuildingBlocked() && !_config.canSpawnBuildingBlocked)
+            if (!_config.canSpawnBuildingBlocked && player.IsBuildingBlocked())
             {
-                player.ChatMessage(lang.GetMessage("mini_priv", this, player.UserIDString));
+                player.ChatMessage(lang.GetMessage("mini_buildingblocked", this, player.UserIDString));
                 return;
             }
 
@@ -590,6 +596,9 @@ namespace Oxide.Plugins
             [JsonProperty("CanSpawnBuildingBlocked")]
             public bool canSpawnBuildingBlocked = false;
 
+            [JsonProperty("CanFetchBuildingBlocked")]
+            public bool canFetchBuildlingBlocked = true;
+
             [JsonProperty("FuelAmount")]
             public int fuelAmount = 0;
 
@@ -640,7 +649,7 @@ namespace Oxide.Plugins
                 ["mini_perm"] = "You do not have permission to use this command!",
                 ["mini_current"] = "You already have a minicopter!",
                 ["mini_notcurrent"] = "You do not have a minicopter!",
-                ["mini_priv"] = "Cannot spawn a minicopter because you're building blocked!",
+                ["mini_buildingblocked"] = "Cannot do that while building blocked!",
                 ["mini_timeleft_new"] = "You have <color=red>{0}</color> until your cooldown ends",
                 ["mini_sdistance"] = "You're trying to spawn the minicopter too far away!",
                 ["mini_terrain"] = "Trying to spawn minicopter outside of terrain!",
@@ -656,7 +665,6 @@ namespace Oxide.Plugins
                 ["mini_perm"] = "У вас нет разрешения на использование этой команды!",
                 ["mini_current"] = "У вас уже есть мини-вертолет!",
                 ["mini_notcurrent"] = "У вас нет мини-вертолета!",
-                ["mini_priv"] = "Невозможно вызвать мини-вертолет, потому что ваше здание заблокировано!",
                 ["mini_timeleft_new"] = "У вас есть <color=red>{0}</color>, пока ваше время восстановления не закончится.",
                 ["mini_sdistance"] = "Вы пытаетесь породить миникоптер слишком далеко!",
                 ["mini_terrain"] = "Попытка породить мини-вертолет вне местности!",
@@ -670,7 +678,6 @@ namespace Oxide.Plugins
                 ["mini_perm"] = "Du habe keine keine berechtigung diesen befehl zu verwenden!",
                 ["mini_current"] = "Du hast bereits einen minikopter!",
                 ["mini_notcurrent"] = "Du hast keine minikopter!",
-                ["mini_priv"] = "Ein minikopter kann nicht hervorgebracht, da das bauwerk ist verstopft!",
                 ["mini_timeleft_new"] = "Du hast <color=red>{0}</color>, bis ihre abklingzeit ende",
                 ["mini_sdistance"] = "Du bist versuchen den minikopter zu weit weg zu spawnen!",
                 ["mini_terrain"] = "Du versucht laichen einen minikopter außerhalb des geländes!",

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -585,7 +585,6 @@ namespace Oxide.Plugins
                 ["mini_terrain"] = "Trying to spawn minicopter outside of terrain!",
                 ["mini_mounted"] = "A player is currenty mounted on the minicopter!",
                 ["mini_current_distance"] = "The minicopter is too far!",
-                ["mini_rcon"] = "This command can only be run from RCON!",
                 ["mini_canmount"] = "You are not the owner of this Minicopter or in the owner's team!"
             }, this, "en");
             lang.RegisterMessages(new Dictionary<string, string>
@@ -600,7 +599,6 @@ namespace Oxide.Plugins
                 ["mini_terrain"] = "Попытка породить мини-вертолет вне местности!",
                 ["mini_mounted"] = "Игрок в данный момент сидит на миникоптере или это слишком далеко!",
                 ["mini_current_distance"] = "Мини-вертолет слишком далеко!",
-                ["mini_rcon"] = "Эту команду можно запустить только из RCON!",
                 ["mini_canmount"] = "Вы не являетесь владельцем этого Minicopter или в команде владельца!"
             }, this, "ru");
             lang.RegisterMessages(new Dictionary<string, string>

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -2,6 +2,7 @@ using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using Newtonsoft.Json.Serialization;
 using Oxide.Core;
+using Oxide.Core.Libraries.Covalence;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -40,7 +41,7 @@ namespace Oxide.Plugins
             if (!Interface.Oxide.DataFileSystem.ExistsDatafile(Name))
                 Interface.Oxide.DataFileSystem.GetDatafile(Name).Save();
 
-            _data = Interface.Oxide.DataFileSystem.ReadObject<SaveData>(Name);
+            LoadSaveData();
 
             if (!_config.ownerOnly)
                 Unsubscribe(nameof(CanMountEntity));
@@ -495,6 +496,18 @@ namespace Oxide.Plugins
         #endregion
 
         #region Data & Configuration
+
+        private SaveData LoadSaveData()
+        {
+            _data = Interface.Oxide.DataFileSystem.ReadObject<SaveData>(Name);
+            if (_data == null)
+            {
+                PrintWarning($"Data file {Name}.json is invalid. Creating new data file.");
+                _data = new SaveData();
+                WriteSaveData();
+            }
+            return _data;
+        }
 
         private void WriteSaveData() =>
             Interface.Oxide.DataFileSystem.WriteObject(Name, _data);


### PR DESCRIPTION
- Minicopters can no longer be spawned or fetched in the underground train tunnels
- An informative message is now printed to the player when they try to loot the fuel container of a minicopter with unlimited fuel
- The plugin will now auto recover when the data files become corrupt, instead of throwing `NullReferenceException` errors
- There is a new `FuelAmountsRequiringPermission` config option, which can be used to generate permissions like `spawnmini.fuel.<amount>` so that the initial fuel amount can be different for minicopters spawned by particular players or groups
- There is a new `CanFetchWhileOccupied` config option (defaults to `true` for backwards compatibility), which you can set to `false` to prevent players from using `/fmini` while building blocked
- The Russian and German translations are now incomplete, so let us know if you would like to contribute translations