### PR TITLE
Change how unlimited fuel is implemented

### DIFF
--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -10,7 +10,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.11.1"), Description("Spawn a mini!")]
+    [Info("Spawn Mini", "SpooksAU", "2.11.2"), Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
         private SaveData _data;
@@ -519,11 +519,10 @@ namespace Oxide.Plugins
 
         private void EnableUnlimitedFuel(MiniCopter minicopter)
         {
-            minicopter.fuelPerSec = 0f;
-
-            StorageContainer fuelContainer = minicopter.GetFuelSystem().GetFuelContainer();
-            fuelContainer.inventory.AddItem(fuelContainer.allowedItem, 1);
-            fuelContainer.SetFlag(BaseEntity.Flags.Locked, true);
+            var fuelSystem = minicopter.GetFuelSystem();
+            fuelSystem.cachedHasFuel = true;
+            fuelSystem.nextFuelCheckTime = float.MaxValue;
+            fuelSystem.GetFuelContainer().SetFlag(BaseEntity.Flags.Locked, true);
         }
 
         private float GetDistance(BasePlayer player, MiniCopter mini)


### PR DESCRIPTION
This change addresses a conflict with the Skill Tree plugin, where players with the perk to reduce helicopter fuel consumption were having the fuel consumption overriden from 0 to another value by that plugin. To solve that conflict, the proposed implementation simply disables fuel checks for minicopters spawned by players with the unlimited fuel permission.

The conflict was reported here:
https://umod.org/community/spawn-mini/43221-flies-for-a-few-seconds-than-lands

The proposed approach might introduce new plugin conflicts, which we can address as they are reported, but the approach of disabling fuel checks seems to me to be more correct than altering fuel consumption.