### PR TITLE
Improvements to spawning, fetching and despawning

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Default configuration:
   "MaxNoMiniDistance": -1.0,
   "MaxSpawnDistance": 5.0,
   "UseFixedSpawnDistance": true,
+  "FixedSpawnDistance": 3.0,
+  "FixedSpawnRotationAngle": 135.0,
   "OwnerAndTeamCanMount": false,
   "DefaultCooldown": 86400.0,
   "PermissionCooldowns": {
@@ -67,6 +69,8 @@ Options explained:
 * `MaxNoMiniDistance` -- The maximum distance players can be from their minicopter to use `/nomini` or `/fmini`. Set to `-1` to allow those commands at unlimited distance.
 * `MaxSpawnDistance` -- The maximum distance away that players are allowed to spawn their minicopter.
 * `UseFixedSpawnDistance` (`true` or `false`) -- Set to `true` to cause minicopters to spawn directly in front of players at a fixed distance, disregarding the `MaxSpawnDistance` setting. Performs no terrain checks.
+* `FixedSpawnDistance` -- Distance from the player to spawn or fetch the mini, while `UseFixedSpawnDistance` is `true`.
+* `FixedSpawnRotationAngle` -- Angle to rotate the mini relative to the player when spawning or fetching, while `UseFixedSpawnDistance` is `true`.
 * `OwnerAndTeamCanMount` (`true` or `false`) -- Set to `true` to only allow the owner and their team members to be able to mount the minicopter.
 * `DefaultCooldown` -- The default spawn cooldown that will apply to players who have not been granted any permissions in `PermissionCooldowns`.
 * `PermissionCooldowns` -- Use these settings to customize cooldowns for different player groups. For example, set `"spawnmini.tier1": 3600.0` and then grant the `spawnmini.tier1` permission to a group of players to assign them a 1 hour cooldown for spawning their minicopters.

--- a/README.md
+++ b/README.md
@@ -5,13 +5,13 @@
 * `spawnmini.nomini` -- Allows player to use `/nomini` chat command
 * `spawnmini.nodecay` -- Doesn't allow the player's minicopter to decay
 * `spawnmini.unlimitedfuel` -- Gives the player unlimited fuel when they spawn their minicopter
-* `spawnmini.fmini` -- Allows player to use `/fmini` chat command
+* `spawnmini.fmini` -- Allows player to use `/fmini` chat command, and allows `/mymini` to fetch the existing mini while the `AutoFetch` config option is enabled
 * `spawnmini.fuel.<amount>` -- Determines the amount of fuel the player's minicopter spawns with, overriding the `FuelAmount` config value
   * To use this, you must first add the desired amount in the `FuelAmountsRequiringPermission` config option
 
 ## Chat Commands
 
-* `/mymini` -- Spawn a minicopter
+* `/mymini` -- Spawn or fetch your minicopter
 * `/nomini` -- Despawn your minicopter
 * `/fmini` -- Fetch your minicopter
 
@@ -38,6 +38,7 @@ Default configuration:
   "CanFetchWhileOccupied": false,
   "CanSpawnBuildingBlocked": false,
   "CanFetchBuildingBlocked": true,
+  "AutoFetch": false,
   "FuelAmount": 0,
   "FuelAmountsRequiringPermission": [],
   "MaxNoMiniDistance": -1.0,
@@ -60,6 +61,7 @@ Options explained:
 * `CanFetchWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/fmini` while the minicopter is mounted. Mounted players will be dismounted automatically. Regardless of this setting, players cannot fetched their minicopter while they are mounted on it.
 * `CanSpawnBuildingBlocked` (`true` or `false`) -- Whether to allow players to spawn a minicopter while building blocked.
 * `CanFetchBuildingBlocked` (`true` or `false`) -- Whether to allow players to use `/fmini` while building blocked.
+* `AutoFetch` (`true` or `false`) -- Whether to automatically fetch your existing mini when using the `/mymini` command, if you have the `spawnmini.fmini` permission.
 * `FuelAmount` -- Amount of low grade fuel to add to minicopters when spawned. Set to `-1` for max stack size (which depends on the server, but is 500 in vanilla). Does not apply to minicopters spawned for players who have the `spawnmini.unlimitedfuel` permission.
 * `FuelAmountsRequiringPermission` -- Use this to customize the fuel amount for different player groups. Simply add the desire fuel amounts like `[100, 200]`, and reload the plugin to generate permissions of the format `spawnmini.fuel.<amount>`. Granting one to a player will cause their mini to spawn with that amount of low grade fuel, overriding the default `FuelAmount`. If you grant multiple of these permission to a player, the last will apply, based on the order in the config.
 * `MaxNoMiniDistance` -- The maximum distance players can be from their minicopter to use `/nomini` or `/fmini`. Set to `-1` to allow those commands at unlimited distance.

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Default configuration:
   "CanSpawnBuildingBlocked": false,
   "CanFetchBuildingBlocked": true,
   "AutoFetch": false,
+  "RepairOnFetch": false,
   "FuelAmount": 0,
   "FuelAmountsRequiringPermission": [],
   "MaxNoMiniDistance": -1.0,
@@ -64,6 +65,7 @@ Options explained:
 * `CanSpawnBuildingBlocked` (`true` or `false`) -- Whether to allow players to spawn a minicopter while building blocked.
 * `CanFetchBuildingBlocked` (`true` or `false`) -- Whether to allow players to use `/fmini` while building blocked.
 * `AutoFetch` (`true` or `false`) -- Whether to automatically fetch your existing mini when using the `/mymini` command, if you have the `spawnmini.fmini` permission.
+* `RepairOnFetch` (`true` or `false`) -- Whether to repair the mini when fetched with `/fmini`.
 * `FuelAmount` -- Amount of low grade fuel to add to minicopters when spawned. Set to `-1` for max stack size (which depends on the server, but is 500 in vanilla). Does not apply to minicopters spawned for players who have the `spawnmini.unlimitedfuel` permission.
 * `FuelAmountsRequiringPermission` -- Use this to customize the fuel amount for different player groups. Simply add the desire fuel amounts like `[100, 200]`, and reload the plugin to generate permissions of the format `spawnmini.fuel.<amount>`. Granting one to a player will cause their mini to spawn with that amount of low grade fuel, overriding the default `FuelAmount`. If you grant multiple of these permission to a player, the last will apply, based on the order in the config.
 * `MaxNoMiniDistance` -- The maximum distance players can be from their minicopter to use `/nomini` or `/fmini`. Set to `-1` to allow those commands at unlimited distance.

--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ Default configuration:
   "FixedSpawnDistance": 3.0,
   "FixedSpawnRotationAngle": 135.0,
   "OwnerAndTeamCanMount": false,
-  "DefaultSpawnCooldown": 86400.0,
+  "DefaultSpawnCooldown": 3600.0,
   "PermissionSpawnCooldowns": {
-    "spawnmini.tier1": 43200.0,
-    "spawnmini.tier2": 21600.0,
-    "spawnmini.tier3": 10800.0
+    "spawnmini.tier1": 600.0,
+    "spawnmini.tier2": 300.0,
+    "spawnmini.tier3": 60.0
   },
   "DefaultFetchCooldown": 0.0,
   "PermissionFetchCooldowns": {

--- a/README.md
+++ b/README.md
@@ -48,11 +48,17 @@ Default configuration:
   "FixedSpawnDistance": 3.0,
   "FixedSpawnRotationAngle": 135.0,
   "OwnerAndTeamCanMount": false,
-  "DefaultCooldown": 86400.0,
-  "PermissionCooldowns": {
+  "DefaultSpawnCooldown": 86400.0,
+  "PermissionSpawnCooldowns": {
     "spawnmini.tier1": 43200.0,
     "spawnmini.tier2": 21600.0,
     "spawnmini.tier3": 10800.0
+  },
+  "DefaultFetchCooldown": 0.0,
+  "PermissionFetchCooldowns": {
+    "spawnmini.fetch.tier1": 600.0,
+    "spawnmini.fetch.tier2": 300.0,
+    "spawnmini.fetch.tier3": 60.0
   },
   "SpawnHealth": 750.0,
   "DestroyOnDisconnect": false
@@ -74,10 +80,15 @@ Options explained:
 * `FixedSpawnDistance` -- Distance from the player to spawn or fetch the mini, while `UseFixedSpawnDistance` is `true`.
 * `FixedSpawnRotationAngle` -- Angle to rotate the mini relative to the player when spawning or fetching, while `UseFixedSpawnDistance` is `true`.
 * `OwnerAndTeamCanMount` (`true` or `false`) -- Set to `true` to only allow the owner and their team members to be able to mount the minicopter.
-* `DefaultCooldown` -- The default spawn cooldown that will apply to players who have not been granted any permissions in `PermissionCooldowns`.
-* `PermissionCooldowns` -- Use these settings to customize cooldowns for different player groups. For example, set `"spawnmini.tier1": 3600.0` and then grant the `spawnmini.tier1` permission to a group of players to assign them a 1 hour cooldown for spawning their minicopters.
+* `DefaultSpawnCooldown` -- The default spawn cooldown that will apply to players who have not been granted any permissions in `PermissionSpawnCooldowns`.
+* `PermissionSpawnCooldowns` -- Use these settings to customize spawn cooldowns for different player groups. For example, set `"spawnmini.tier1": 3600.0` and then grant the `spawnmini.tier1` permission to a group of players to assign them a 1 hour cooldown for spawning their minicopters.
   * If a player has multiple cooldown permissions, the lowest is used.
-  * If a player has no cooldown permissions, `DefaultCooldown` will be used for them.
+  * If a player has no cooldown permissions, `DefaultSpawnCooldown` will be used for them.
+  * You can add as many cooldown tiers as you would like, but you should prefix them all with `spawnmini.` to prevent warnings in the server logs.
+* `DefaultFetchCooldown` -- The default spawn cooldown that will apply to players who have not been granted any permissions in `PermissionFetchCooldowns`.
+* `PermissionFetchCooldowns` -- Use these settings to customize fetch cooldowns for different player groups. For example, set `"spawnmini.fetch.tier1": 3600.0` and then grant the `spawnmini.fetch.tier1` permission to a group of players to assign them a 1 hour cooldown for fetching their minicopters.
+  * If a player has multiple cooldown permissions, the lowest is used.
+  * If a player has no cooldown permissions, `DefaultFetchCooldown` will be used for them.
   * You can add as many cooldown tiers as you would like, but you should prefix them all with `spawnmini.` to prevent warnings in the server logs.
 * `SpawnHealth` -- The health minicopters will spawn with.
 * `DestroyOnDisconnect` (`true` or `false`) -- Set to `true` to destroy each spawned minicopter when its owner disconnects from the server. If the minicopter is mounted, it will be destroyed when fully dismounted.

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Default configuration:
 ```
 
 Options explained:
-* `CanDespawnWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/nomini` while their minicopter is mounted. Regardless of this setting, players cannot despawn their minicopter while they are mounted on it.
+* `CanDespawnWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/nomini` while their minicopter is mounted.
 * `CanFetchWhileOccupied` (`true` or `false`) -- Whether to allow players to use `/fmini` while the minicopter is mounted. Mounted players will be dismounted automatically. Regardless of this setting, players cannot fetched their minicopter while they are mounted on it.
 * `CanSpawnBuildingBlocked` (`true` or `false`) -- Whether to allow players to spawn a minicopter while building blocked.
 * `CanFetchBuildingBlocked` (`true` or `false`) -- Whether to allow players to use `/fmini` while building blocked.

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -692,7 +692,7 @@ namespace Oxide.Plugins
             public bool ownerOnly = false;
 
             [JsonProperty("DefaultSpawnCooldown")]
-            public float defaultSpawnCooldown = 86400f;
+            public float defaultSpawnCooldown = 3600f;
 
             [JsonProperty("DefaultCooldown")]
             private float deprecatedDefaultSpawnCooldown
@@ -703,9 +703,9 @@ namespace Oxide.Plugins
             [JsonProperty("PermissionSpawnCooldowns", ObjectCreationHandling = ObjectCreationHandling.Replace)]
             public Dictionary<string, float> spawnPermissionCooldowns = new Dictionary<string, float>()
             {
-                ["spawnmini.tier1"] = 43200f,
-                ["spawnmini.tier2"] = 21600f,
-                ["spawnmini.tier3"] = 10800f,
+                ["spawnmini.tier1"] = 600f,
+                ["spawnmini.tier2"] = 300f,
+                ["spawnmini.tier3"] = 60f,
             };
 
             [JsonProperty("PermissionCooldowns")]

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -218,12 +218,6 @@ namespace Oxide.Plugins
                 return;
             }
 
-            if (IsLocationRestricted(player.transform.position))
-            {
-                player.ChatMessage(lang.GetMessage("mini_location_restricted", this, player.UserIDString));
-                return;
-            }
-
             if (SpawnWasBlocked(player))
                 return;
 
@@ -371,12 +365,6 @@ namespace Oxide.Plugins
         private TimeSpan CeilingTimeSpan(TimeSpan timeSpan) =>
             new TimeSpan((long)Math.Ceiling(1.0 * timeSpan.Ticks / 10000000) * 10000000);
 
-        private bool IsLocationRestricted(Vector3 position)
-        {
-            // Disallow spawning in underground train tunnels
-            return position.y < -100;
-        }
-
         private bool IsMiniBeyondMaxDistance(BasePlayer player, MiniCopter mini) =>
             _config.noMiniDistance >= 0 && GetDistance(player, mini) > _config.noMiniDistance;
 
@@ -426,12 +414,6 @@ namespace Oxide.Plugins
             if (IsMiniBeyondMaxDistance(player, mini))
             {
                 player.ChatMessage(lang.GetMessage("mini_current_distance", this, player.UserIDString));
-                return;
-            }
-
-            if (IsLocationRestricted(player.transform.position))
-            {
-                player.ChatMessage(lang.GetMessage("mini_location_restricted", this, player.UserIDString));
                 return;
             }
 

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -425,6 +425,11 @@ namespace Oxide.Plugins
                     mountPoint.mountable?.DismountAllPlayers();
             }
 
+            if (_config.repairOnFetch)
+            {
+                mini.SetHealth(Math.Max(mini.Health(), _config.spawnHealth));
+            }
+
             mini.rigidBody.velocity = Vector3.zero;
             mini.transform.SetPositionAndRotation(GetFixedPositionForPlayer(player), GetFixedRotationForPlayer(player));
             mini.UpdateNetworkGroup();
@@ -617,6 +622,9 @@ namespace Oxide.Plugins
 
             [JsonProperty("AutoFetch")]
             public bool autoFetch = false;
+
+            [JsonProperty("RepairOnFetch")]
+            public bool repairOnFetch = false;
 
             [JsonProperty("FuelAmount")]
             public int fuelAmount = 0;

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -276,6 +276,8 @@ namespace Oxide.Plugins
             }
 
             mini.transform.SetPositionAndRotation(GetIdealFixedPositionForPlayer(player), GetIdealRotationForPlayer(player));
+            mini.UpdateNetworkGroup();
+            mini.SendNetworkUpdateImmediate();
         }
 
         [ChatCommand("nomini")]

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -9,7 +9,7 @@ using UnityEngine;
 
 namespace Oxide.Plugins
 {
-    [Info("Spawn Mini", "SpooksAU", "2.11.2")]
+    [Info("Spawn Mini", "SpooksAU", "2.12.0")]
     [Description("Spawn a mini!")]
     class SpawnMini : RustPlugin
     {
@@ -268,7 +268,7 @@ namespace Oxide.Plugins
                 return;
             }
 
-            if (mini.AnyMounted() && (!_config.canDespawnWhileOccupied || player.GetMountedVehicle() == mini))
+            if (mini.AnyMounted() && !_config.canDespawnWhileOccupied)
             {
                 player.ChatMessage(lang.GetMessage("mini_mounted", this, player.UserIDString));
                 return;

--- a/SpawnMini.cs
+++ b/SpawnMini.cs
@@ -196,7 +196,7 @@ namespace Oxide.Plugins
             var mini = FindPlayerMini(player);
             if (mini != null)
             {
-                if (_config.AutoFetch && permission.UserHasPermission(player.UserIDString, _fetchMini))
+                if (_config.autoFetch && permission.UserHasPermission(player.UserIDString, _fetchMini))
                 {
                     FetchInternal(player, mini);
                 }
@@ -360,15 +360,15 @@ namespace Oxide.Plugins
         private bool IsMiniBeyondMaxDistance(BasePlayer player, MiniCopter mini) =>
             _config.noMiniDistance >= 0 && GetDistance(player, mini) > _config.noMiniDistance;
 
-        private Vector3 GetIdealFixedPositionForPlayer(BasePlayer player)
+        private Vector3 GetFixedPositionForPlayer(BasePlayer player)
         {
             Vector3 forward = player.GetNetworkRotation() * Vector3.forward;
             forward.y = 0;
-            return player.transform.position + forward.normalized * 3f + Vector3.up * 2f;
+            return player.transform.position + forward.normalized * _config.fixedSpawnDistance + Vector3.up * 2f;
         }
 
-        private Quaternion GetIdealRotationForPlayer(BasePlayer player) =>
-            Quaternion.Euler(0, player.GetNetworkRotation().eulerAngles.y - 135, 0);
+        private Quaternion GetFixedRotationForPlayer(BasePlayer player) =>
+            Quaternion.Euler(0, player.GetNetworkRotation().eulerAngles.y - _config.fixedSpawnRotationAngle, 0);
 
         private MiniCopter FindPlayerMini(BasePlayer player)
         {
@@ -426,7 +426,7 @@ namespace Oxide.Plugins
             }
 
             mini.rigidBody.velocity = Vector3.zero;
-            mini.transform.SetPositionAndRotation(GetIdealFixedPositionForPlayer(player), GetIdealRotationForPlayer(player));
+            mini.transform.SetPositionAndRotation(GetFixedPositionForPlayer(player), GetFixedRotationForPlayer(player));
             mini.UpdateNetworkGroup();
             mini.SendNetworkUpdateImmediate();
         }
@@ -443,7 +443,7 @@ namespace Oxide.Plugins
 
             if (_config.useFixedSpawnDistance)
             {
-                position = GetIdealFixedPositionForPlayer(player);
+                position = GetFixedPositionForPlayer(player);
             }
             else
             {
@@ -464,7 +464,7 @@ namespace Oxide.Plugins
                 position = hit.point + Vector3.up * 2f;
             }
 
-            MiniCopter mini = GameManager.server.CreateEntity(_config.assetPrefab, position, GetIdealRotationForPlayer(player)) as MiniCopter;
+            MiniCopter mini = GameManager.server.CreateEntity(_config.assetPrefab, position, GetFixedRotationForPlayer(player)) as MiniCopter;
             if (mini == null) return;
 
             mini.OwnerID = player.userID;
@@ -493,8 +493,8 @@ namespace Oxide.Plugins
                 return;
             }
 
-            var position = useCustomPosition ? customPosition : GetIdealFixedPositionForPlayer(player);
-            var rotation = useCustomPosition ? Quaternion.identity : GetIdealRotationForPlayer(player);
+            var position = useCustomPosition ? customPosition : GetFixedPositionForPlayer(player);
+            var rotation = useCustomPosition ? Quaternion.identity : GetFixedRotationForPlayer(player);
 
             MiniCopter mini = GameManager.server.CreateEntity(_config.assetPrefab, position, rotation) as MiniCopter;
             if (mini == null) return;
@@ -616,7 +616,7 @@ namespace Oxide.Plugins
             public bool canFetchBuildlingBlocked = true;
 
             [JsonProperty("AutoFetch")]
-            public bool AutoFetch = false;
+            public bool autoFetch = false;
 
             [JsonProperty("FuelAmount")]
             public int fuelAmount = 0;
@@ -632,6 +632,12 @@ namespace Oxide.Plugins
 
             [JsonProperty("UseFixedSpawnDistance")]
             public bool useFixedSpawnDistance = true;
+
+            [JsonProperty("FixedSpawnDistance")]
+            public float fixedSpawnDistance = 3;
+
+            [JsonProperty("FixedSpawnRotationAngle")]
+            public float fixedSpawnRotationAngle = 135;
 
             [JsonProperty("OwnerAndTeamCanMount")]
             public bool ownerOnly = false;


### PR DESCRIPTION
- Added `AutoFetch` config option which makes the `/mymini` command automatically fetch the existing mini
- Added `RepairOnFetch` config option which determines whether fetching the mini will automatically repair it
- Added `FixedSpawnDistance` config option to determine how far away the mini will spawn from the player, while `UseFixedSpawnDistance` is `true`
- Added `FixedSpawnRotationAngle` config option to determine the mini rotation when spawned, relative to the player, while `UseFixedSpawnDistance` is `true`
- Added optional fetch cooldowns: `DefaultFetchCooldown` and `PermissionFetchCooldowns`
- Fixed bug where the minicopter would be invisible for a few seconds after fetched
- Players can now despawn their mini while they are in it, while the `CanDespawnWhileOccupied` config option is `true`